### PR TITLE
Replaced characters in ARC filename which FAT32 does not support

### DIFF
--- a/src/arc.c
+++ b/src/arc.c
@@ -72,6 +72,10 @@ int write_arc(t_mra *mra, char *filename) {
     if (n >= MAX_LINE_LENGTH) printf("%s:%d: warning: line was truncated while writing in ARC file!\n", __FILE__, __LINE__);
     fwrite(buffer, 1, n, out);
 
+    if( mra->n_switches ) {
+        n = snprintf(buffer, MAX_LINE_LENGTH, "DEFAULT=%X\n", mra->switches_default );
+        fwrite(buffer, 1, n, out);
+    }
     for (i = 0; i < mra->n_switches; i++) {
         if (mra->switches[i].ids) {
             n = snprintf(buffer, MAX_LINE_LENGTH, "CONF=\"%s,%s,%s\"\n", format_bits(mra->switches + i), mra->switches[i].name, mra->switches[i].ids);

--- a/src/arc.c
+++ b/src/arc.c
@@ -84,3 +84,11 @@ int write_arc(t_mra *mra, char *filename) {
     fclose(out);
     return 0;
 }
+
+void make_fat32_compatible( char *filename ) {
+    int k;
+    for( k=0; filename[k]; k++ ) {
+        if( filename[k] == ':' ) filename[k] = '_';
+        if( filename[k] == '?' ) filename[k] = '_';
+    }
+}

--- a/src/arc.c
+++ b/src/arc.c
@@ -84,11 +84,3 @@ int write_arc(t_mra *mra, char *filename) {
     fclose(out);
     return 0;
 }
-
-void make_fat32_compatible( char *filename ) {
-    int k;
-    for( k=0; filename[k]; k++ ) {
-        if( filename[k] == ':' ) filename[k] = '_';
-        if( filename[k] == '?' ) filename[k] = '_';
-    }
-}

--- a/src/arc.c
+++ b/src/arc.c
@@ -73,7 +73,7 @@ int write_arc(t_mra *mra, char *filename) {
     fwrite(buffer, 1, n, out);
 
     if( mra->n_switches ) {
-        n = snprintf(buffer, MAX_LINE_LENGTH, "DEFAULT=%X\n", mra->switches_default );
+        n = snprintf(buffer, MAX_LINE_LENGTH, "DEFAULT=0x%X\n", mra->switches_default );
         fwrite(buffer, 1, n, out);
     }
     for (i = 0; i < mra->n_switches; i++) {

--- a/src/arc.h
+++ b/src/arc.h
@@ -4,5 +4,6 @@
 #include "mra.h"
 
 int write_arc(t_mra *mra, char *filename);
+void make_fat32_compatible( char *filename );
 
 #endif

--- a/src/arc.h
+++ b/src/arc.h
@@ -4,6 +4,5 @@
 #include "mra.h"
 
 int write_arc(t_mra *mra, char *filename);
-void make_fat32_compatible( char *filename );
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -166,7 +166,7 @@ void main(int argc, char **argv) {
             } else {
                 arc_filename = get_filename(output_dir ? output_dir : ".", mra.name ? mra.name : mra_basename, "arc");
             }
-
+            make_fat32_compatible( arc_filename );
             if (verbose) {
                 printf("Creating ARC file %s\n", arc_filename);
             }

--- a/src/mra.c
+++ b/src/mra.c
@@ -205,11 +205,12 @@ int read_switches(XMLNode *node, t_dip_switch **switches, int *n_switches, int *
     for( i=0; i < node->n_attributes; i++ ) {
         XMLAttribute *attr = &node->attributes[i];
         if( strncmp( attr->name, "default", 8) ==0 ) {
-            int a,b,c,n; // up to three values
-            n = sscanf( attr->value, "%X,%X,%X", &a,&b,&c );
-            if( n-- >0 ) dip_default &= (a|0xffff00);
-            if( n-- >0 ) dip_default &= ((b<<8)|0xff00ff);
-            if( n-- >0 ) dip_default &= ((c<<16)|0x00ffff);
+            int a,b,c,d,n; // up to three values
+            n = sscanf( attr->value, "%X,%X,%X,%X", &a,&b,&c,&d );
+            if( n-- >0 ) dip_default &= (a      |0xffffff00);
+            if( n-- >0 ) dip_default &= ((b<<8) |0xffff00ff);
+            if( n-- >0 ) dip_default &= ((c<<16)|0xff00ffff);
+            if( n-- >0 ) dip_default &= ((d<<24)|0x00ffffff);
             break;
         }
     }

--- a/src/mra.h
+++ b/src/mra.h
@@ -73,6 +73,7 @@ typedef struct s_mra {
     
     t_dip_switch *switches;
     int n_switches;
+    int switches_default;
     
     t_rom *roms;
     int n_roms;

--- a/src/utils.c
+++ b/src/utils.c
@@ -209,3 +209,11 @@ char *string_list_add(t_string_list *list, char *element) {
     free(elementCopy);
     return list->elements[list->n_elements - 1];
 }
+
+void make_fat32_compatible( char *filename ) {
+    int k;
+    for( k=0; filename[k]; k++ ) {
+        if( filename[k] == ':' ) filename[k] = '_';
+        if( filename[k] == '?' ) filename[k] = '_';
+    }
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -31,4 +31,6 @@ t_string_list *string_list_new(char *pipe_separated_list);
 char *string_list_add(t_string_list *list, char *element);
 char *string_list_to_string(t_string_list *list);
 
+void make_fat32_compatible( char *filename );
+
 #endif

--- a/tests/results/Test ARC Creation.arc
+++ b/tests/results/Test ARC Creation.arc
@@ -2,6 +2,7 @@
 RBF=TEST_ARC
 MOD=10
 NAME=ROMNAME
+DEFAULT=0xFFC9FFFF
 CONF="T5,Soft Reset"
 CONF="(null),Error Test"
 CONF="OF,Cabinet,Cocktail,Upright"

--- a/tests/results/custom name.arc
+++ b/tests/results/custom name.arc
@@ -2,6 +2,7 @@
 RBF=TEST_ARC
 MOD=10
 NAME=CUSTOM NAME
+DEFAULT=0xFFC9FFFF
 CONF="T5,Soft Reset"
 CONF="(null),Error Test"
 CONF="OF,Cabinet,Cocktail,Upright"


### PR DESCRIPTION
Characters such as : and ? which are ok for displaying in the OSD or for some filesystems cannot be used on ARC files that target FAT32 filesystems.