### PR TITLE
Arc filename

### DIFF
--- a/src/mra.h
+++ b/src/mra.h
@@ -73,7 +73,7 @@ typedef struct s_mra {
     
     t_dip_switch *switches;
     int n_switches;
-    int switches_default;
+    int switches_default, switches_base;
     
     t_rom *roms;
     int n_roms;


### PR DESCRIPTION
    Added support for:
    mist-rbf   element: overrides the rbf element when defined.
    mist-base  attribute for switches. Adds that number to all bit indexes of DIP switches
    
    Adds more reports of warnings and errors.
    
    Corrects the order of the default DIP value
