### PR TITLE
Sanitize arc filename

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -167,10 +167,13 @@ void main(int argc, char **argv) {
                 if (output_dir) {
                     arc_filename = get_filename(output_dir, get_basename(arc_filename, 1), "arc");
                 }
+                make_fat32_compatible(arc_filename, 0);
             } else {
-                arc_filename = get_filename(output_dir ? output_dir : ".", mra.name ? mra.name : mra_basename, "arc");
+                char *arc_mra_filename = strdup(mra.name ? mra.name : mra_basename);
+                make_fat32_compatible(arc_mra_filename, 1);
+                arc_filename = get_filename(output_dir ? output_dir : ".", arc_mra_filename, "arc");
+                free(arc_mra_filename);
             }
-            make_fat32_compatible( arc_filename );
             if (verbose) {
                 printf("Creating ARC file %s\n", arc_filename);
             }

--- a/src/utils.c
+++ b/src/utils.c
@@ -220,10 +220,32 @@ char *string_list_add(t_string_list *list, char *element) {
     return list->elements[list->n_elements - 1];
 }
 
-void make_fat32_compatible( char *filename ) {
+char *trim(char *str)
+{
+  char *end;
+
+  if (!str) return str;
+
+  while (isspace((unsigned char)*str)) str++;
+
+  if (*str == 0) return str;
+
+  end = str + strlen(str) - 1;
+  while (end > str && isspace((unsigned char)*end)) end--;
+
+  end[1] = '\0';
+
+  return str;
+}
+
+void make_fat32_compatible(char *filename, int stripslashes) {
     int k;
-    for( k=0; filename[k]; k++ ) {
-        if( filename[k] == ':' ) filename[k] = '_';
-        if( filename[k] == '?' ) filename[k] = '_';
+
+    for (k = 0; filename[k]; k++) {
+        if (filename[k] == ':') filename[k] = '_';
+        if (filename[k] == '?') filename[k] = '_';
+        if ((stripslashes) && (filename[k] == '/')) filename[k] = '_';
+        if (filename[k] < ' ') filename[k] = ' ';
+        trim(filename);
     }
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -32,6 +32,6 @@ t_string_list *string_list_new(char *pipe_separated_list);
 char *string_list_add(t_string_list *list, char *element);
 char *string_list_to_string(t_string_list *list);
 
-void make_fat32_compatible( char *filename );
+void make_fat32_compatible(char *filename, int stripslashes);
 
 #endif


### PR DESCRIPTION
When trying to create the Tokio ROM from Jotego's mra file mra tool is unable to create the arc file, because the name in the mra file contains invalid chars (slash, new line):
```
mist@mist:/tmp/jt$ ~/git/mra-tools-c/mra -v -z . -A Tokio\ -\ Scramble\ Formation\ \(bootleg\).mra 
zip include dirs: ./, ./
Creating ARC file ./Tokio / Scramble Formation (bootleg)
        .arc
Couldn't open ./Tokio / Scramble Formation (bootleg)
        .arc for writing!
Writing ARC file failed with error code: -1
. Retry without -A if you still want to create the ROM file.
```

This pull request enhances ```make_fat32_compatible()``` to sanitize the arc filename.
